### PR TITLE
Docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+	"name": "Your Dev Container",
+	"image": "docker.io/benjaminluohc/file_processing_tools:latest"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea/
+__pycache__
+.github/
+directory_test_files/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10.12-slim
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y \
+    ffmpeg \
+    tesseract-ocr \
+    git
+
+RUN pip install git+https://github.com/hc-sc-ocdo-bdpd/file-processing-tools.git
+
+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To begin installation, clone this repository and then follow one of the below op
 
 > Pre-requisite(s): `Python (v3)`, `ffmpeg`, `Tesseract`. See [here](https://hc-sc-ocdo-bdpd.github.io/file-processing-tools/1_tutorial/1_installation.html#additional-dependencies) for installation. These are not hard requirements; they are used for transcription (audio-to-text) and OCR (image-to-text)
 
-Create the virtual environment: `View` > `Python: Create Environment` > `Venv` > `your-python-version` > `requirements.txt`
+Create the virtual environment in VSCode: `View` (top left of the screen) > `Python: Create Environment` > `Venv` > `your-python-version` > `requirements.txt`
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,37 @@
 # file_processing_tools_template
 A demo project of the file_processing_tools library: https://github.com/hc-sc-ocdo-bdpd/file-processing-tools
 
-Setup this project using a virtual environment and import the contents of requirements.txt.
+<br>
+
+## Installation
+
+To begin installation, clone this repository and then follow one of the below options.
+
+<br>
+
+### Option 1: `venv`
+
+> Pre-requisite(s): `Python (v3)`, `ffmpeg`, `Tesseract`. See [here](https://hc-sc-ocdo-bdpd.github.io/file-processing-tools/1_tutorial/1_installation.html#additional-dependencies) for installation. These are not hard requirements; they are used for transcription (audio-to-text) and OCR (image-to-text)
+
+Create the virtual environment: `View` > `Python: Create Environment` > `Venv` > `your-python-version` > `requirements.txt`
+
+<br>
+
+### Option 2: `Dockerfile`
+
+> Pre-requisite(s): Docker
+
+1. Install the VSCode extension: `Remote Development` (by Microsoft)
+2. In the top navigation menu: `View` > `Command Palette` > `Dev Containers: Rebuild and Reopen in Container`
+
+If step 2 does not work, then try after replacing the code in `.devcontainer/devcontainer.json` with the following:
+
+```json
+{
+	"name": "My Container",
+	"build": {
+		"context": "..",
+		"dockerfile": "../Dockerfile"
+	}
+}
+```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To begin installation, clone this repository and then follow one of the below op
 
 > Pre-requisite(s): `Python (v3)`, `ffmpeg`, `Tesseract`. See [here](https://hc-sc-ocdo-bdpd.github.io/file-processing-tools/1_tutorial/1_installation.html#additional-dependencies) for installation. These are not hard requirements; they are used for transcription (audio-to-text) and OCR (image-to-text)
 
-Create the virtual environment in VSCode: `View` (top left of the screen) > `Python: Create Environment` > `Venv` > `your-python-version` > `requirements.txt`
+Create the virtual environment in VSCode: `View` (top left of the screen) > `Command Palette` > `Python: Create Environment` > `Venv` > `your-python-version` > `requirements.txt`
 
 <br>
 


### PR DESCRIPTION
Added `Dockerfile` and `devcontainer.json` as a means of installation (separate from the existing option of creating a `venv`) and included documentation

**How it works:** The parent repository builds the image as part of a CI/CD pipeline and uploads it to [Dockerhub](https://hub.docker.com/r/benjaminluohc/file_processing_tools/tags). This child repository then reads the image via `devcontainer.json`:

```json
{
	"name": "Your Dev Container",
	"image": "docker.io/benjaminluohc/file_processing_tools:latest"
}
```

As a contingency for when I'm no longer here, I added a separate means of setup. That is, creating the container using the child repository's Dockerfile, which directly pip installs the parent directory. This removes the need for `Dockerhub` but also entails the modification of the `devcontainer.json` file to the following:

```json
{
	"name": "My Container",
	"build": {
		"context": "..",
		"dockerfile": "../Dockerfile"
	}
}
```